### PR TITLE
Correct number of scope types

### DIFF
--- a/scope.html
+++ b/scope.html
@@ -116,7 +116,7 @@
             including:
           </p>
           <ul>
-            <li>the scope type (there are 11 of them!)
+            <li>the scope type (there are 12 of them!)
             <li>the AST node associated with the scope
             <li>variables declared within that scope, each of which points to its declarations and references
             <li>whether the scope contains a <code>with</code> statement or direct call to eval, making it dynamic


### PR DESCRIPTION
There are [12](https://github.com/shapesecurity/shift-scope-js/blob/a39809051576101c0154fdaa2837e8bfefc73ff2/src/scope.js#L26-L37).
