### PR TITLE
Add regexp acceptor to shift tools list

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,6 +283,14 @@
                   <td>&mdash;</td>
                 </tr>
                 <tr>
+                  <th>Regexp Acceptor</th>
+                  <td>&mdash;</td>
+                  <td>&mdash;</td>
+                  <td><a href="https://github.com/shapesecurity/shift-regexp-acceptor-js/tree/es2016">JS</a></td>
+                  <td><a href="https://github.com/shapesecurity/shift-regexp-acceptor-js/tree/es2016">JS</a></td>
+                  <td><a href="https://github.com/shapesecurity/shift-regexp-acceptor-js/tree/es2018">JS</a></td>
+                </tr>
+                <tr>
                   <th>AST Constructors</th>
                   <td><a href="https://github.com/shapesecurity/shift-ast-js/tree/es5">JS</a></td>
                   <td><a href="https://github.com/shapesecurity/shift-ast-js/tree/es6">JS</a> + <a href="https://github.com/shapesecurity/shift-java/tree/es2016/generated-sources/main/java/com/shapesecurity/shift/ast">Java</a></td>


### PR DESCRIPTION
Does not include reference to Java implementation, as it is not yet merged.