### PR TITLE
fix shift template link in support table

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,7 +278,7 @@
                   <td>&mdash;</td>
                 </tr>
                 <tr>
-                  <th><a href="estree-converter.html">Shift Template</a></th>
+                  <th><a href="template.html">Shift Template</a></th>
                   <td>&mdash;</td>
                   <td><a href="https://github.com/shapesecurity/shift-template-js/tree/es2016">JS</a> + <a href="https://github.com/shapesecurity/shift-java/tree/es2016/src/main/java/com/shapesecurity/shift/es2016/template">Java</a></td>
                   <td><a href="https://github.com/shapesecurity/shift-template-js/tree/es2017">JS</a> + <a href="https://github.com/shapesecurity/shift-java/tree/es2017/src/main/java/com/shapesecurity/shift/es2017/template">Java</a></td>


### PR DESCRIPTION
shift template was incorrectly linked to estree-converter.html rather than template.html in support table

CLA pr @ shapesecurity/CLA/pull/38